### PR TITLE
Fix segmentation plots in reports for input files that are non RAS oriented

### DIFF
--- a/scripts/manage_results/create_prediction_report.py
+++ b/scripts/manage_results/create_prediction_report.py
@@ -335,8 +335,15 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
         file_hipo_seg = os.path.join(hippunfold_folder, f'sub-{subject}', 'anat', f'sub-{subject}_hemi-{hemi}_space-cropT1w_desc-subfields_atlas-bigbrain_dseg.nii.gz')
 
         #load images
-        img_array = sitk.GetArrayFromImage(sitk.ReadImage(file_hipo, sitk.sitkFloat32))  # convert to sitk object
-        seg_array = sitk.GetArrayFromImage(sitk.ReadImage(file_hipo_seg, sitk.sitkInt64))
+        img = sitk.ReadImage(file_hipo, sitk.sitkFloat32)
+        seg = sitk.ReadImage(file_hipo_seg, sitk.sitkInt64)
+        img = sitk.DICOMOrient(img, 'RAS') # reorient to RAS to make sure plotting works as expected
+        seg = sitk.DICOMOrient(seg, 'RAS')
+        img_array = sitk.GetArrayFromImage(img)
+        seg_array = sitk.GetArrayFromImage(seg)
+
+        # convert to RAS orientation
+        img_array = np.flip(img_array, axis=1)
 
         # get cmap
         _ , cmap_labels = return_labels_cmap()

--- a/scripts/manage_results/create_prediction_report.py
+++ b/scripts/manage_results/create_prediction_report.py
@@ -387,9 +387,11 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
 
         fig.savefig(output_file, dpi=96, transparent =True)
 
-def create_surf_plot(borders, faces, vertices, cmap=False, file='./tmp.png'):
+def create_surf_plot(borders, faces, vertices, cmap=False, file=None):
     """plot and reload surface images"""
     from hippunfold_toolbox import plotting
+    if file is None:
+        file = tempfile.NamedTemporaryFile(suffix='.png').name
     fig, ax_temp = plt.subplots(nrows=1, ncols=1, figsize=(8,8), subplot_kw={'projection': "3d"})
     plotting.surfplot_cdata(ax_temp,borders,faces,vertices, cmap=cmap)
     ax_temp.view_init(elev=90, azim=-90)

--- a/scripts/manage_results/create_prediction_report.py
+++ b/scripts/manage_results/create_prediction_report.py
@@ -342,9 +342,6 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
         img_array = sitk.GetArrayFromImage(img)
         seg_array = sitk.GetArrayFromImage(seg)
 
-        # convert to RAS orientation
-        img_array = np.flip(img_array, axis=1)
-
         # get cmap
         _ , cmap_labels = return_labels_cmap()
 
@@ -352,7 +349,7 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
         img_array = np.rot90(img_array, 2)
         seg_array = np.rot90(seg_array, 2)
         x,y,z = coords_seg_extract(seg_array)
-        axs[0,i].imshow(img_array[x,:,:], cmap='gray')
+        axs[0,i].imshow(img_array[x,:,:], origin='lower', cmap='gray')
         axs[0,i].imshow(seg_array[x,:,:], origin='lower', cmap=cmap_labels, alpha=0.4)
         axs[0,i].axis('off')
         axs[0,i].text(1, 125, 'R', fontsize = 8, color='red')

--- a/scripts/new_patient_pipeline/run_pipeline_prediction.py
+++ b/scripts/new_patient_pipeline/run_pipeline_prediction.py
@@ -443,8 +443,10 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
 
         fig.savefig(output_file, dpi=96, transparent =True)
 
-def create_surf_plot(borders, faces, vertices, cmap=False, file='/tmp/tmp.png'):
+def create_surf_plot(borders, faces, vertices, cmap=False, file=None):
     """plot and reload surface images"""
+    if file is None:
+        file = tempfile.NamedTemporaryFile(suffix='.png').name
     fig, ax_temp = plt.subplots(nrows=1, ncols=1, figsize=(8,8), subplot_kw={'projection': "3d"})
     plotting.surfplot_cdata(ax_temp,borders,faces,vertices, cmap=cmap)
     ax_temp.view_init(elev=90, azim=-90)

--- a/scripts/new_patient_pipeline/run_pipeline_prediction.py
+++ b/scripts/new_patient_pipeline/run_pipeline_prediction.py
@@ -406,15 +406,19 @@ def plot_segmentations_subject(subject, hippunfold_folder, output_file, hemis=['
         file_hipo_seg = os.path.join(hippunfold_folder, 'hippunfold', subject_bids, 'anat', f'{subject_bids}_hemi-{hemi}_space-cropT1w_desc-subfields_atlas-bigbrain_dseg.nii.gz')
 
         #load images
-        img_array = sitk.GetArrayFromImage(sitk.ReadImage(file_hipo, sitk.sitkFloat32))  # convert to sitk object
-        seg_array = sitk.GetArrayFromImage(sitk.ReadImage(file_hipo_seg, sitk.sitkInt64))
+        img = sitk.ReadImage(file_hipo, sitk.sitkFloat32)
+        seg = sitk.ReadImage(file_hipo_seg, sitk.sitkInt64)
+        img = sitk.DICOMOrient(img, 'RAS') # reorient to RAS to make sure plotting works as expected
+        seg = sitk.DICOMOrient(seg, 'RAS')
+        img_array = sitk.GetArrayFromImage(img)
+        seg_array = sitk.GetArrayFromImage(seg)
 
         # get cmap
         _ , cmap_labels = return_labels_cmap()
 
         # plot on conventional coronal view
         x,y,z = coords_seg_extract(seg_array)
-        axs[0,i].imshow(np.fliplr(img_array[:,y,:]), cmap='gray')
+        axs[0,i].imshow(np.fliplr(img_array[:,y,:]), origin='lower', cmap='gray')
         axs[0,i].imshow(np.fliplr(seg_array[:,y,:]), origin='lower', cmap=cmap_labels, alpha=0.4)
         axs[0,i].axis('off')
         axs[0,i].text(1, 125, 'R', fontsize = 8, color='red')


### PR DESCRIPTION
The function exists twice, in scripts/manage_results/create_prediction_report.py and scripts/new_patient_pipeline/run_pipeline_prediction.py, apparently the latter is used for report generation